### PR TITLE
Atlantis parallel plans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,117 +3,21 @@ jobs:
   test:
     working_directory: /go/src/github.com/runatlantis/atlantis
     docker:
-    - image: runatlantis/testing-env:latest
+      - image: runatlantis/testing-env:latest
     steps:
-    - checkout
-    - run: make test-coverage
-    - run:
-        name: post coverage to codecov.io
-        command: bash <(curl -s https://codecov.io/bash)
-    - run: make check-fmt
-    - run: make check-lint
-  e2e:
-    working_directory: /go/src/github.com/runatlantis/atlantis
-    docker:
-    - image: circleci/golang:1.12
-      environment:
-        # This version of TF will be downloaded before Atlantis is started.
-        # We do this instead of setting --default-tf-version because setting
-        # that flag starts the download asynchronously so we'd have a race
-        # condition.
-        TERRAFORM_VERSION: 0.12.1
-    steps:
-    - checkout
-    - run: make build-service
-    # We don't run e2e tests on fork PRs because they don't have access to the secret env vars.
-    - run: if [ -z "${CIRCLE_PR_REPONAME}" ]; then ./scripts/e2e.sh; fi
+      - checkout
+      - run: make test-coverage
+      - run:
+          name: post coverage to codecov.io
+          command: bash <(curl -s https://codecov.io/bash)
+      - run: make check-fmt
+      - run: make check-lint
 
-  # Check that there's no missing links for the website.
-  # This job builds the website, starts a server to serve it, and then uses
-  # muffet (https://github.com/raviqqe/muffet) to perform the link check.
-  website_link_check:
-    docker:
-      # This image's Dockerfile is at runatlantis.io/Dockerfile
-    - image: runatlantis/ci-link-checker:0.1
-    steps:
-    - checkout
-    - run: yarn install
-    - run: yarn website:build
-    - run:
-        name: http-server
-        command: http-server runatlantis.io/.vuepress/dist
-        background: true
-      # We use dockerize -wait here to wait until the server is up.
-    - run: |
-        dockerize -wait tcp://localhost:8080 -- \
-          muffet \
-            -e 'https://github\.com/runatlantis/atlantis/edit/master/.*' \
-            -e 'https://github.com/helm/charts/tree/master/stable/atlantis#customization' \
-            http://localhost:8080/
-
-  # Build and push 'latest' Docker tag.
-  docker_master:
-    working_directory: /go/src/github.com/runatlantis/atlantis
-    docker:
-    - image: circleci/golang:1.12
-    steps:
-    - checkout
-    - run: make build-service
-    - setup_remote_docker
-    - run:
-        name: Build image
-        command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            docker build -t runatlantis/atlantis:latest .
-          fi
-    - run:
-        name: Push image
-        command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-            docker push runatlantis/atlantis:latest
-          fi
-  # Build and push Docker tag.
-  docker_tag:
-    working_directory: /go/src/github.com/runatlantis/atlantis
-    docker:
-    - image: circleci/golang:1.12
-    steps:
-    - checkout
-    - run: make build-service
-    - setup_remote_docker
-    - run:
-        name: Build and tag
-        command: |
-          if [ -n "${CIRCLE_TAG}" ]; then
-            docker build -t "runatlantis/atlantis:${CIRCLE_TAG}" .
-            docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-            docker push "runatlantis/atlantis:${CIRCLE_TAG}"
-          fi
 workflows:
   version: 2
   branch:
     jobs:
-    - test:
-        filters:
-          branches:
-            ignore: /.*-docs/
-    - e2e:
-        requires: [test]
-        filters:
-          branches:
-            ignore: /.*-docs/
-    - docker_master:
-        requires: [e2e]
-        filters:
-          branches:
-            only: master
-    - website_link_check
-  tag:
-    jobs:
-    - docker_tag:
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /^v.*/
+      - test:
+          filters:
+            branches:
+              ignore: /.*-docs/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules/
 **/.vuepress/dist
 helm/test-values.yaml
 *.swp
+bin/

--- a/server/events/models/models.go
+++ b/server/events/models/models.go
@@ -298,9 +298,11 @@ type ProjectCommandContext struct {
 	// ApplyRequirements is the list of requirements that must be satisfied
 	// before we will run the apply stage.
 	ApplyRequirements []string
-	// AutoplanEnabled is true if automerge is enabled for the repo that this
+	// AutomergeEnabled is true if automerge is enabled for the repo that this
 	// project is in.
 	AutomergeEnabled bool
+	// ParallelPlansEnabled is true if parallel plans is enabled for this project.
+	ParallelPlansEnabled bool
 	// AutoplanEnabled is true if autoplanning is enabled for this project.
 	AutoplanEnabled bool
 	// BaseRepo is the repository that the pull request will be merged into.

--- a/server/events/project_command_builder.go
+++ b/server/events/project_command_builder.go
@@ -21,6 +21,8 @@ const (
 	DefaultWorkspace = "default"
 	// DefaultAutomergeEnabled is the default for the automerge setting.
 	DefaultAutomergeEnabled = false
+	// DefaultParallelPlansEnabled is the default for the parallel plans setting.
+	DefaultParallelPlansEnabled = false
 )
 
 //go:generate pegomock generate -m --use-experimental-model-gen --package mocks -o mocks/mock_project_command_builder.go ProjectCommandBuilder
@@ -137,7 +139,7 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext,
 		for _, mp := range matchingProjects {
 			ctx.Log.Debug("determining config for project at dir: %q workspace: %q", mp.Dir, mp.Workspace)
 			mergedCfg := p.GlobalCfg.MergeProjectCfg(ctx.Log, ctx.BaseRepo.ID(), mp, repoCfg)
-			projCtxs = append(projCtxs, p.buildCtx(ctx, models.PlanCommand, mergedCfg, commentFlags, repoCfg.Automerge, verbose))
+			projCtxs = append(projCtxs, p.buildCtx(ctx, models.PlanCommand, mergedCfg, commentFlags, repoCfg.Automerge, repoCfg.ParallelPlans, verbose))
 		}
 	} else {
 		// If there is no config file, then we'll plan each project that
@@ -148,7 +150,7 @@ func (p *DefaultProjectCommandBuilder) buildPlanAllCommands(ctx *CommandContext,
 		for _, mp := range modifiedProjects {
 			ctx.Log.Debug("determining config for project at dir: %q", mp.Path)
 			pCfg := p.GlobalCfg.DefaultProjCfg(ctx.Log, ctx.BaseRepo.ID(), mp.Path, DefaultWorkspace)
-			projCtxs = append(projCtxs, p.buildCtx(ctx, models.PlanCommand, pCfg, commentFlags, DefaultAutomergeEnabled, verbose))
+			projCtxs = append(projCtxs, p.buildCtx(ctx, models.PlanCommand, pCfg, commentFlags, DefaultAutomergeEnabled, DefaultParallelPlansEnabled, verbose))
 		}
 	}
 
@@ -279,10 +281,12 @@ func (p *DefaultProjectCommandBuilder) buildProjectCommandCtx(
 	}
 
 	automerge := DefaultAutomergeEnabled
+	parallelPlans := DefaultParallelPlansEnabled
 	if repoCfgPtr != nil {
 		automerge = repoCfgPtr.Automerge
+		parallelPlans = repoCfgPtr.ParallelPlans
 	}
-	return p.buildCtx(ctx, cmd, projCfg, commentFlags, automerge, verbose), nil
+	return p.buildCtx(ctx, cmd, projCfg, commentFlags, automerge, parallelPlans, verbose), nil
 }
 
 // getCfg returns the atlantis.yaml config (if it exists) for this project. If
@@ -371,6 +375,7 @@ func (p *DefaultProjectCommandBuilder) buildCtx(ctx *CommandContext,
 	projCfg valid.MergedProjectCfg,
 	commentArgs []string,
 	automergeEnabled bool,
+	parallelPlansEnabled bool,
 	verbose bool) models.ProjectCommandContext {
 
 	var steps []valid.Step
@@ -382,24 +387,25 @@ func (p *DefaultProjectCommandBuilder) buildCtx(ctx *CommandContext,
 	}
 
 	return models.ProjectCommandContext{
-		ApplyCmd:          p.CommentBuilder.BuildApplyComment(projCfg.RepoRelDir, projCfg.Workspace, projCfg.Name),
-		BaseRepo:          ctx.BaseRepo,
-		CommentArgs:       commentArgs,
-		AutomergeEnabled:  automergeEnabled,
-		AutoplanEnabled:   projCfg.AutoplanEnabled,
-		Steps:             steps,
-		HeadRepo:          ctx.HeadRepo,
-		Log:               ctx.Log,
-		PullMergeable:     ctx.PullMergeable,
-		Pull:              ctx.Pull,
-		ProjectName:       projCfg.Name,
-		ApplyRequirements: projCfg.ApplyRequirements,
-		RePlanCmd:         p.CommentBuilder.BuildPlanComment(projCfg.RepoRelDir, projCfg.Workspace, projCfg.Name, commentArgs),
-		RepoRelDir:        projCfg.RepoRelDir,
-		RepoConfigVersion: projCfg.RepoCfgVersion,
-		TerraformVersion:  projCfg.TerraformVersion,
-		User:              ctx.User,
-		Verbose:           verbose,
-		Workspace:         projCfg.Workspace,
+		ApplyCmd:             p.CommentBuilder.BuildApplyComment(projCfg.RepoRelDir, projCfg.Workspace, projCfg.Name),
+		BaseRepo:             ctx.BaseRepo,
+		CommentArgs:          commentArgs,
+		AutomergeEnabled:     automergeEnabled,
+		ParallelPlansEnabled: parallelPlansEnabled,
+		AutoplanEnabled:      projCfg.AutoplanEnabled,
+		Steps:                steps,
+		HeadRepo:             ctx.HeadRepo,
+		Log:                  ctx.Log,
+		PullMergeable:        ctx.PullMergeable,
+		Pull:                 ctx.Pull,
+		ProjectName:          projCfg.Name,
+		ApplyRequirements:    projCfg.ApplyRequirements,
+		RePlanCmd:            p.CommentBuilder.BuildPlanComment(projCfg.RepoRelDir, projCfg.Workspace, projCfg.Name, commentArgs),
+		RepoRelDir:           projCfg.RepoRelDir,
+		RepoConfigVersion:    projCfg.RepoCfgVersion,
+		TerraformVersion:     projCfg.TerraformVersion,
+		User:                 ctx.User,
+		Verbose:              verbose,
+		Workspace:            projCfg.Workspace,
 	}
 }

--- a/server/events/yaml/raw/repo_cfg.go
+++ b/server/events/yaml/raw/repo_cfg.go
@@ -10,12 +10,16 @@ import (
 // DefaultAutomerge is the default setting for automerge.
 const DefaultAutomerge = false
 
+// DefaultParallelPlans is the default setting for parallel plans
+const DefaultParallelPlans = false
+
 // RepoCfg is the raw schema for repo-level atlantis.yaml config.
 type RepoCfg struct {
-	Version   *int                `yaml:"version,omitempty"`
-	Projects  []Project           `yaml:"projects,omitempty"`
-	Workflows map[string]Workflow `yaml:"workflows,omitempty"`
-	Automerge *bool               `yaml:"automerge,omitempty"`
+	Version       *int                `yaml:"version,omitempty"`
+	Projects      []Project           `yaml:"projects,omitempty"`
+	Workflows     map[string]Workflow `yaml:"workflows,omitempty"`
+	Automerge     *bool               `yaml:"automerge,omitempty"`
+	ParallelPlans *bool               `yaml:"parallel_plans,omitempty"`
 }
 
 func (r RepoCfg) Validate() error {
@@ -52,10 +56,16 @@ func (r RepoCfg) ToValid() valid.RepoCfg {
 		automerge = *r.Automerge
 	}
 
+	parallelPlans := DefaultParallelPlans
+	if r.ParallelPlans != nil {
+		parallelPlans = *r.ParallelPlans
+	}
+
 	return valid.RepoCfg{
-		Version:   *r.Version,
-		Projects:  validProjects,
-		Workflows: validWorkflows,
-		Automerge: automerge,
+		Version:       *r.Version,
+		Projects:      validProjects,
+		Workflows:     validWorkflows,
+		Automerge:     automerge,
+		ParallelPlans: parallelPlans,
 	}
 }

--- a/server/events/yaml/raw/repo_cfg_test.go
+++ b/server/events/yaml/raw/repo_cfg_test.go
@@ -112,10 +112,21 @@ func TestConfig_UnmarshalYAML(t *testing.T) {
 			expErr: "yaml: unmarshal errors:\n  line 2: cannot unmarshal !!str `notabool` into bool",
 		},
 		{
+			description: "parallel plans not a boolean",
+			input:       "version: 3\nparallel_plans: notabool",
+			exp: raw.RepoCfg{
+				Version:   nil,
+				Projects:  nil,
+				Workflows: nil,
+			},
+			expErr: "yaml: unmarshal errors:\n  line 2: cannot unmarshal !!str `notabool` into bool",
+		},
+		{
 			description: "should use values if set",
 			input: `
 version: 3
 automerge: true
+parallel_plans: true
 projects:
 - dir: mydir
   workspace: myworkspace
@@ -132,8 +143,9 @@ workflows:
     apply:
      steps: []`,
 			exp: raw.RepoCfg{
-				Version:   Int(3),
-				Automerge: Bool(true),
+				Version:       Int(3),
+				Automerge:     Bool(true),
+				ParallelPlans: Bool(true),
 				Projects: []raw.Project{
 					{
 						Dir:              String("mydir"),
@@ -236,38 +248,43 @@ func TestConfig_ToValid(t *testing.T) {
 			},
 		},
 		{
-			description: "automerge ommitted",
+			description: "automerge and parallel_plans ommitted",
 			input: raw.RepoCfg{
 				Version: Int(2),
 			},
 			exp: valid.RepoCfg{
-				Version:   2,
-				Automerge: false,
-				Workflows: map[string]valid.Workflow{},
+				Version:       2,
+				Automerge:     false,
+				ParallelPlans: false,
+				Workflows:     map[string]valid.Workflow{},
 			},
 		},
 		{
-			description: "automerge true",
+			description: "automerge and parallel_plans true",
 			input: raw.RepoCfg{
-				Version:   Int(2),
-				Automerge: Bool(true),
+				Version:       Int(2),
+				Automerge:     Bool(true),
+				ParallelPlans: Bool(true),
 			},
 			exp: valid.RepoCfg{
-				Version:   2,
-				Automerge: true,
-				Workflows: map[string]valid.Workflow{},
+				Version:       2,
+				Automerge:     true,
+				ParallelPlans: true,
+				Workflows:     map[string]valid.Workflow{},
 			},
 		},
 		{
-			description: "automerge false",
+			description: "automerge and parallel_plans false",
 			input: raw.RepoCfg{
-				Version:   Int(2),
-				Automerge: Bool(false),
+				Version:       Int(2),
+				Automerge:     Bool(false),
+				ParallelPlans: Bool(false),
 			},
 			exp: valid.RepoCfg{
-				Version:   2,
-				Automerge: false,
-				Workflows: map[string]valid.Workflow{},
+				Version:       2,
+				Automerge:     false,
+				ParallelPlans: false,
+				Workflows:     map[string]valid.Workflow{},
 			},
 		},
 		{
@@ -282,8 +299,9 @@ func TestConfig_ToValid(t *testing.T) {
 				},
 			},
 			exp: valid.RepoCfg{
-				Version:   2,
-				Automerge: false,
+				Version:       2,
+				Automerge:     false,
+				ParallelPlans: false,
 				Workflows: map[string]valid.Workflow{
 					"myworkflow": {
 						Name: "myworkflow",
@@ -302,8 +320,9 @@ func TestConfig_ToValid(t *testing.T) {
 		{
 			description: "everything set",
 			input: raw.RepoCfg{
-				Version:   Int(2),
-				Automerge: Bool(true),
+				Version:       Int(2),
+				Automerge:     Bool(true),
+				ParallelPlans: Bool(true),
 				Workflows: map[string]raw.Workflow{
 					"myworkflow": {
 						Apply: &raw.Stage{
@@ -329,8 +348,9 @@ func TestConfig_ToValid(t *testing.T) {
 				},
 			},
 			exp: valid.RepoCfg{
-				Version:   2,
-				Automerge: true,
+				Version:       2,
+				Automerge:     true,
+				ParallelPlans: true,
 				Workflows: map[string]valid.Workflow{
 					"myworkflow": {
 						Name: "myworkflow",

--- a/server/events/yaml/valid/repo_cfg.go
+++ b/server/events/yaml/valid/repo_cfg.go
@@ -7,10 +7,11 @@ import version "github.com/hashicorp/go-version"
 // RepoCfg is the atlantis.yaml config after it's been parsed and validated.
 type RepoCfg struct {
 	// Version is the version of the atlantis YAML file.
-	Version   int
-	Projects  []Project
-	Workflows map[string]Workflow
-	Automerge bool
+	Version       int
+	Projects      []Project
+	Workflows     map[string]Workflow
+	Automerge     bool
+	ParallelPlans bool
 }
 
 func (r RepoCfg) FindProjectsByDirWorkspace(repoRelDir string, workspace string) []Project {


### PR DESCRIPTION
This PR adds the ability to run plan commands in go routines. By default this is turned off and can be enabled in the repo-level `atlantis.yaml` file:
```
version: 2
automerge: true
parallel_plans: true
...
```

This requires that all terraform projects in your `atlantis.yaml` are using [terraform workspaces](https://www.terraform.io/docs/state/workspaces.html) in order to avoid lock collisions

```
# with parallel plans (2 workspaces):
2019/07/08 17:18:39-0700 [INFO] Running plans in parallel
2019/07/08 17:18:39-0700 [INFO] Acquired lock with id "segmentio/xx-dev-1"
2019/07/08 17:18:39-0700 [INFO] Creating dir "/dev-2"
2019/07/08 17:18:39-0700 [INFO] Acquired lock with id "segmentio/xx-dev-2"
2019/07/08 17:18:39-0700 [INFO] Creating dir "/dev-1"
2019/07/08 17:18:39-0700 [INFO] server: POST /events – from [::1]:57593
2019/07/08 17:18:39-0700 [INFO] server: POST /events – respond HTTP 200
2019/07/08 17:18:44-0700 [INFO] Successfully ran init "dev-1"
2019/07/08 17:18:44-0700 [INFO] Successfully ran init "dev-2"
...

# without
2019/07/08 17:20:14-0700 [INFO] Acquired lock with id "dev-1"
2019/07/08 17:20:14-0700 [INFO] Creating dir "dev-1"
2019/07/08 17:20:21-0700 [INFO] Successfully ran init "dev-1"
2019/07/08 17:20:21-0700 [INFO] Successfully ran show "dev-1"
...
```