### PR TITLE
Use a sized wait group and expose pool size flag for config

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -486,6 +486,14 @@
   version = "v0.8.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:bb90467981c5e812c4d1c78e498a1416b04cb5149dc5fa2200ab758c37488f6f"
+  name = "github.com/remeh/sizedwaitgroup"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5e7302b12ccef91dce9fde2f5bda6d5c7ea5d2eb"
+
+[[projects]]
   digest = "1:9e9193aa51197513b3abcb108970d831fbcf40ef96aa845c4f03276e1fa316d2"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
@@ -806,6 +814,7 @@
     "github.com/nlopes/slack",
     "github.com/petergtz/pegomock",
     "github.com/pkg/errors",
+    "github.com/remeh/sizedwaitgroup",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
     "github.com/spf13/viper",

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -58,6 +58,7 @@ const (
 	GitlabUserFlag             = "gitlab-user"
 	GitlabWebhookSecretFlag    = "gitlab-webhook-secret" // nolint: gosec
 	LogLevelFlag               = "log-level"
+	ParallelPlansPoolSize      = "parallel-plans-pool-size"
 	PortFlag                   = "port"
 	RepoConfigFlag             = "repo-config"
 	RepoConfigJSONFlag         = "repo-config-json"
@@ -71,13 +72,14 @@ const (
 	TFETokenFlag               = "tfe-token"
 
 	// Flag defaults.
-	DefaultCheckoutStrategy = "branch"
-	DefaultBitbucketBaseURL = bitbucketcloud.BaseURL
-	DefaultDataDir          = "~/.atlantis"
-	DefaultGHHostname       = "github.com"
-	DefaultGitlabHostname   = "gitlab.com"
-	DefaultLogLevel         = "info"
-	DefaultPort             = 4141
+	DefaultCheckoutStrategy      = "branch"
+	DefaultBitbucketBaseURL      = bitbucketcloud.BaseURL
+	DefaultDataDir               = "~/.atlantis"
+	DefaultGHHostname            = "github.com"
+	DefaultGitlabHostname        = "gitlab.com"
+	DefaultLogLevel              = "info"
+	DefaultParallelPlansPoolSize = 10
+	DefaultPort                  = 4141
 )
 
 var stringFlags = map[string]stringFlag{
@@ -222,6 +224,10 @@ var boolFlags = map[string]boolFlag{
 	},
 }
 var intFlags = map[string]intFlag{
+	ParallelPlansPoolSize: {
+		description:  "Max size of the wait group that runs parallel plans (if enabled).",
+		defaultValue: DefaultParallelPlansPoolSize,
+	},
 	PortFlag: {
 		description:  "Port to bind to.",
 		defaultValue: DefaultPort,

--- a/server/server.go
+++ b/server/server.go
@@ -253,6 +253,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		AllowForkPRs:             userConfig.AllowForkPRs,
 		AllowForkPRsFlag:         config.AllowForkPRsFlag,
 		DisableApplyAll:          userConfig.DisableApplyAll,
+		ParallelPlansPoolSize:    userConfig.ParallelPlansPoolSize,
 		ProjectCommandBuilder: &events.DefaultProjectCommandBuilder{
 			ParserValidator:   validator,
 			ProjectFinder:     &events.DefaultProjectFinder{},

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -26,6 +26,7 @@ type UserConfig struct {
 	GitlabUser             string `mapstructure:"gitlab-user"`
 	GitlabWebhookSecret    string `mapstructure:"gitlab-webhook-secret"`
 	LogLevel               string `mapstructure:"log-level"`
+	ParallelPlansPoolSize  int    `mapstructure:"parallel-plans-pool-size"`
 	Port                   int    `mapstructure:"port"`
 	RepoConfig             string `mapstructure:"repo-config"`
 	RepoConfigJSON         string `mapstructure:"repo-config-json"`

--- a/vendor/github.com/remeh/sizedwaitgroup/LICENSE
+++ b/vendor/github.com/remeh/sizedwaitgroup/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Rémy Mathieu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/remeh/sizedwaitgroup/README.md
+++ b/vendor/github.com/remeh/sizedwaitgroup/README.md
@@ -1,0 +1,54 @@
+# SizedWaitGroup
+
+[![GoDoc](https://godoc.org/github.com/remeh/sizedwaitgroup?status.svg)](https://godoc.org/github.com/remeh/sizedwaitgroup)
+
+`SizedWaitGroup` has the same role and API as `sync.WaitGroup` but it adds a limit of the amount of goroutines started concurrently.
+
+`SizedWaitGroup` adds the feature of limiting the maximum number of concurrently started routines. It could for example be used to start multiples routines querying a database but without sending too much queries in order to not overload the given database.
+
+# Example
+
+```
+package main
+
+import (
+        "fmt"
+        "math/rand"
+        "time"
+
+        "github.com/remeh/sizedwaitgroup"
+)
+
+func main() {
+        rand.Seed(time.Now().UnixNano())
+
+        // Typical use-case:
+        // 50 queries must be executed as quick as possible
+        // but without overloading the database, so only
+        // 8 routines should be started concurrently.
+        swg := sizedwaitgroup.New(8)
+        for i := 0; i < 50; i++ {
+                swg.Add()
+                go func(i int) {
+                        defer swg.Done()
+                        query(i)
+                }(i)
+        }
+
+        swg.Wait()
+}
+
+func query(i int) {
+        fmt.Println(i)
+        ms := i + 500 + rand.Intn(500)
+        time.Sleep(time.Duration(ms) * time.Millisecond)
+}
+```
+
+# License
+
+MIT
+
+# Copyright
+
+Rémy Mathieu © 2016

--- a/vendor/github.com/remeh/sizedwaitgroup/sizedwaitgroup.go
+++ b/vendor/github.com/remeh/sizedwaitgroup/sizedwaitgroup.go
@@ -1,0 +1,84 @@
+// Based upon sync.WaitGroup, SizedWaitGroup allows to start multiple
+// routines and to wait for their end using the simple API.
+
+// SizedWaitGroup adds the feature of limiting the maximum number of
+// concurrently started routines. It could for example be used to start
+// multiples routines querying a database but without sending too much
+// queries in order to not overload the given database.
+//
+// Rémy Mathieu © 2016
+package sizedwaitgroup
+
+import (
+	"context"
+	"math"
+	"sync"
+)
+
+// SizedWaitGroup has the same role and close to the
+// same API as the Golang sync.WaitGroup but adds a limit of
+// the amount of goroutines started concurrently.
+type SizedWaitGroup struct {
+	Size int
+
+	current chan struct{}
+	wg      sync.WaitGroup
+}
+
+// New creates a SizedWaitGroup.
+// The limit parameter is the maximum amount of
+// goroutines which can be started concurrently.
+func New(limit int) SizedWaitGroup {
+	size := math.MaxInt32 // 2^32 - 1
+	if limit > 0 {
+		size = limit
+	}
+	return SizedWaitGroup{
+		Size: size,
+
+		current: make(chan struct{}, size),
+		wg:      sync.WaitGroup{},
+	}
+}
+
+// Add increments the internal WaitGroup counter.
+// It can be blocking if the limit of spawned goroutines
+// has been reached. It will stop blocking when Done is
+// been called.
+//
+// See sync.WaitGroup documentation for more information.
+func (s *SizedWaitGroup) Add() {
+	s.AddWithContext(context.Background())
+}
+
+// AddWithContext increments the internal WaitGroup counter.
+// It can be blocking if the limit of spawned goroutines
+// has been reached. It will stop blocking when Done is
+// been called, or when the context is canceled. Returns nil on
+// success or an error if the context is canceled before the lock
+// is acquired.
+//
+// See sync.WaitGroup documentation for more information.
+func (s *SizedWaitGroup) AddWithContext(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case s.current <- struct{}{}:
+		break
+	}
+	s.wg.Add(1)
+	return nil
+}
+
+// Done decrements the SizedWaitGroup counter.
+// See sync.WaitGroup documentation for more information.
+func (s *SizedWaitGroup) Done() {
+	<-s.current
+	s.wg.Done()
+}
+
+// Wait blocks until the SizedWaitGroup counter is zero.
+// See sync.WaitGroup documentation for more information.
+func (s *SizedWaitGroup) Wait() {
+	s.wg.Wait()
+}


### PR DESCRIPTION
This PR adds a sized wait group for parallel plans so we can cap the number of running threads per webhook request. Default is a pool of size 10.

You can set the pool size with `--parallel-plans-pool-size=5` or `ATLANTIS_PARALLEL_PLANS_POOL_SIZE=5`