### PR TITLE
[CI-163] Switch latency metrics to use dist

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,8 +96,8 @@ require (
 	github.com/onsi/gomega v1.10.1 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/segmentio/stats/v4 v4.6.2
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/segmentio/stats/v4 v4.6.3
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
@@ -113,7 +113,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
-	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
+	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -364,6 +364,9 @@ github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mcdafydd/go-azuredevops v0.12.1 h1:WxwLVyGuJ8oL7uWQp1/J6GefX1wMQQZUHWRGsrm+uE8=
 github.com/mcdafydd/go-azuredevops v0.12.1/go.mod h1:B4UDyn7WEj1/97f45j3VnzEfkWKe05+/dCcAPdOET4A=
+github.com/mdlayher/genetlink v0.0.0-20190313224034-60417448a851/go.mod h1:EsbsAEUEs15qC1cosAwxgCWV0Qhd8TmkxnA9Kw1Vhl4=
+github.com/mdlayher/netlink v0.0.0-20190313131330-258ea9dff42c/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
+github.com/mdlayher/taskstats v0.0.0-20190313225729-7cbba52ee072/go.mod h1:sGdS7A6CAETR53zkdjGkgoFlh1vSm7MtX+i8XfEsTMA=
 github.com/microcosm-cc/bluemonday v1.0.18 h1:6HcxvXDAi3ARt3slx6nTesbvorIc3QeTzBNRvWktHBo=
 github.com/microcosm-cc/bluemonday v1.0.18/go.mod h1:Z0r70sCuXHig8YpBzCc5eGHAap2K7e/u082ZUpDRRqM=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
@@ -447,8 +450,8 @@ github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e h1:uO75wNGioszj
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
 github.com/segmentio/objconv v1.0.1 h1:QjfLzwriJj40JibCV3MGSEiAoXixbp4ybhwfTB8RXOM=
 github.com/segmentio/objconv v1.0.1/go.mod h1:auayaH5k3137Cl4SoXTgrzQcuQDmvuVtZgS0fb1Ahys=
-github.com/segmentio/stats/v4 v4.6.2 h1:++YfKPTOPTZxE1DvavnpeBvB3hlDIm7IM+ULFzbCxCU=
-github.com/segmentio/stats/v4 v4.6.2/go.mod h1:gycE91tyiQw6xg3MT674cVi+CfQ69qHsoNNhXG0C7YQ=
+github.com/segmentio/stats/v4 v4.6.3 h1:Eqxr1x3Ri57FXqCCvQg9WNBlKFeUf2RhrKKnUiXhZFw=
+github.com/segmentio/stats/v4 v4.6.3/go.mod h1:gycE91tyiQw6xg3MT674cVi+CfQ69qHsoNNhXG0C7YQ=
 github.com/segmentio/vpcinfo v0.1.10/go.mod h1:KEIWiWRE/KLh90mOzOY0QkFWT7ObUYLp978tICtquqU=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/scripts/binary-release.sh
+++ b/scripts/binary-release.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# define architecture we want to build
+XC_ARCH=${XC_ARCH:-"386 amd64 arm arm64"}
+XC_OS=${XC_OS:-linux darwin}
+XC_EXCLUDE_OSARCH="!darwin/arm !darwin/386 !darwin/arm64"
+
+# clean up
+echo "-> running clean up...."
+rm -rf output/*
+
+if ! which gox >/dev/null; then
+    echo "-> installing gox..."
+    # Need to run go get in a separate dir
+    # so it doesn't modify our go.mod.
+    SRC_DIR=$(pwd)
+    cd $(mktemp -d)
+    go mod init example.com/m
+    go get -u github.com/mitchellh/gox
+    cd "$SRC_DIR"
+fi
+
+# build
+# we want to build statically linked binaries
+export CGO_ENABLED=0
+echo "-> building..."
+gox \
+    -os="${XC_OS}" \
+    -arch="${XC_ARCH}" \
+    -osarch="${XC_EXCLUDE_OSARCH}" \
+    -output "output/{{.OS}}_{{.Arch}}/atlantis" \
+    .
+
+# Zip and copy to the dist dir
+echo ""
+echo "Packaging..."
+for PLATFORM in $(find ./output -mindepth 1 -maxdepth 1 -type d); do
+    OSARCH=$(basename ${PLATFORM})
+    echo "--> ${OSARCH}"
+
+    pushd $PLATFORM >/dev/null 2>&1
+    zip ../atlantis_${OSARCH}.zip ./*
+    popd >/dev/null 2>&1
+done
+
+echo ""
+echo ""
+echo "-----------------------------------"
+echo "Output:"
+ls -alh output/

--- a/server/events/command_metrics.go
+++ b/server/events/command_metrics.go
@@ -71,7 +71,7 @@ func (ic *instrumentedStepRunner) Run(ctx models.ProjectCommandContext, extraArg
 		ic.stats.Incr("steps.error", tags...)
 		return out, err
 	}
-	ic.stats.ClockAt("steps.duration", start, tags...).Stop()
+	ic.stats.ClockAt("steps.dist_duration", start, tags...).Stop()
 	ic.stats.Incr("steps.success", tags...)
 	return out, err
 }
@@ -95,7 +95,7 @@ func (ic *instrumentedCustomRunner) Run(ctx models.ProjectCommandContext, cmd st
 		ic.stats.Incr("steps.error", tags...)
 		return out, err
 	}
-	ic.stats.ClockAt("steps.duration", start, tags...).Stop()
+	ic.stats.ClockAt("steps.dist_duration", start, tags...).Stop()
 	ic.stats.Incr("steps.success", tags...)
 	return out, err
 }
@@ -119,7 +119,7 @@ func (ic *instrumentedRunner) Run(ctx models.ProjectCommandContext, extraArgs []
 		ic.stats.Incr("steps.error", tags...)
 		return out, err
 	}
-	ic.stats.ClockAt("steps.duration", start, tags...).Stop()
+	ic.stats.ClockAt("steps.dist_duration", start, tags...).Stop()
 	ic.stats.Incr("steps.success", tags...)
 	return out, err
 }

--- a/server/server.go
+++ b/server/server.go
@@ -338,7 +338,10 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		true,
 		projectCmdOutputHandler)
 
-	dd := datadog.NewClient("localhost:8125")
+	dd := datadog.NewClientWith(datadog.ClientConfig{
+		Address:              "localhost:8125",
+		DistributionPrefixes: []string{"dist_"},
+	})
 	stats.Register(dd)
 	defer stats.Flush()
 	// The flag.Lookup call is to detect if we're running in a unit test. If we


### PR DESCRIPTION
## Description
This PR switches our latency metric to use the distribution type instead of histogram so that we're accurately reporting p95 latency for Atlantis operations.

## Testing
I'll test this in stage since I need the statsd agent running to send metrics